### PR TITLE
CORE-724 Add trade-data-matching support, tweaks & logging improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Redeploy the service.
 
 ### Sending alerts for non-tenant services
 
-To send pager duty alerts for non-tenant services (e.g. mongodb, lambdas, workflows etc) add a new entry to `pagerduty-service-override.js`.
+To send pager duty alerts for non-tenant services (e.g. mongodb, lambdas, workflows etc) add a new entry to `service-override.js`.
 
 ```
 {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -389,6 +389,14 @@ const config = convict({
           env: 'PLATFORM_INTEGRATION_KEY'
         }
       },
+      'Trade-Data-Matching': {
+        integrationKey: {
+          doc: 'Integration key for digital service',
+          format: String,
+          default: 'key',
+          env: 'TRADE_DATA_MATCHING_INTEGRATION_KEY'
+        }
+      },
       'platform-tenant-cko': {
         integrationKey: {
           doc: 'Integration key for digital service',

--- a/src/config/service-override.js
+++ b/src/config/service-override.js
@@ -8,7 +8,7 @@
 //     environments: [environments.management, environments.prod],
 //     technicalService: 'my_service'
 //   }
-const serviceToPagerDutyServiceOverride = {
+const serviceToTeamOverride = {
   'cdp-backup': {
     teams: ['platform']
   },
@@ -41,4 +41,4 @@ const serviceToPagerDutyServiceOverride = {
   }
 }
 
-export { serviceToPagerDutyServiceOverride }
+export { serviceToTeamOverride }

--- a/src/helpers/pagerduty/send-alert.js
+++ b/src/helpers/pagerduty/send-alert.js
@@ -3,31 +3,27 @@ import { config } from '~/src/config/index.js'
 
 const url = config.get('pagerduty.url')
 
-async function sendAlert(integrationKey, alert, teams, dedupeKey, eventAction) {
+async function sendAlert(
+  payload,
+  dedupeKey,
+  integrationKey,
+  eventAction,
+  alertURL
+) {
   const response = await proxyFetch(`${url}/v2/enqueue`, {
     method: 'post',
     headers: {
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({
-      payload: {
-        timestamp: alert.startsAt,
-        summary: alert.summary,
-        severity: 'critical',
-        source: 'grafana',
-        custom_details: {
-          teams,
-          service: alert.service,
-          environment: alert.environment
-        }
-      },
+      payload,
       routing_key: integrationKey,
       dedup_key: dedupeKey,
       event_action: eventAction,
       links: [
         {
-          href: alert.alertURL,
-          text: alert.alertURL
+          href: alertURL,
+          text: alertURL
         }
       ]
     })
@@ -35,7 +31,7 @@ async function sendAlert(integrationKey, alert, teams, dedupeKey, eventAction) {
 
   if (!response.ok) {
     throw new Error(
-      `HTTP Error Response: ${response.status} ${response.statusText}`
+      `HTTP Error Response: ${response.status} ${await response.text()}`
     )
   }
   return response

--- a/src/listeners/grafana/email/handle-grafana-email-alerts.js
+++ b/src/listeners/grafana/email/handle-grafana-email-alerts.js
@@ -3,6 +3,7 @@ import { sendEmail } from '~/src/helpers/ms-graph/send-email.js'
 import { fetchTeam } from '~/src/helpers/fetch/fetch-team.js'
 import { fetchService } from '~/src/helpers/fetch/fetch-service.js'
 import { renderEmail } from '~/src/helpers/nunjucks/render-email.js'
+import { serviceToTeamOverride } from '~/src/config/service-override.js'
 
 const sendEmailAlerts = config.get('sendEmailAlerts')
 const sender = config.get('senderEmailAddress')
@@ -23,12 +24,16 @@ function shouldSendAlert(alert) {
   return alertEnvironments.includes(alert.environment)
 }
 
-async function getTeams(alert, logger) {
-  const service = await fetchService(alert.service)
+async function getTeams(serviceName, logger) {
+  const override = serviceToTeamOverride[serviceName]?.teams
+
+  if (override) {
+    return override
+  }
+
+  const service = await fetchService(serviceName)
   if (!service?.teams) {
-    logger.info(
-      `service ${alert.service} was not found:\n${JSON.stringify(alert)}`
-    )
+    logger.info(`service ${serviceName} was not found`)
     return []
   }
 
@@ -43,7 +48,7 @@ async function getTeams(alert, logger) {
  * @returns {Promise<*[string]>}
  */
 async function findContactsForAlert(alert, logger) {
-  const teams = await getTeams(alert, logger)
+  const teams = await getTeams(alert.service, logger)
 
   const contacts = teams.map((team) =>
     team.team?.alertEmailAddresses?.length ? team.team.alertEmailAddresses : []
@@ -56,8 +61,7 @@ async function findContactsForAlert(alert, logger) {
   return uniqueContacts
 }
 
-async function handleGrafanaEmailAlert(message, server) {
-  const logger = server.logger
+async function handleGrafanaEmailAlert(message, logger, msGraph) {
   const payload = JSON.parse(message.Body)
 
   if (!shouldSendAlert(payload)) {
@@ -65,9 +69,7 @@ async function handleGrafanaEmailAlert(message, server) {
   }
 
   if (!payload?.service) {
-    logger.warn(
-      `alert did not contain a service field:\n${JSON.stringify(payload)}`
-    )
+    logger.warn(`alert did not contain a service field`)
     return []
   }
 
@@ -77,28 +79,26 @@ async function handleGrafanaEmailAlert(message, server) {
   } else if (payload.status === 'resolved') {
     email = generateResolvedEmail(payload)
   } else {
-    server.logger.warn(
-      `Unexpected status ${payload.status} not sending alert:\n${JSON.stringify(payload)}`
-    )
+    logger.warn(`Unexpected status ${payload.status} not sending alert`)
     return
   }
 
-  const contacts = await findContactsForAlert(payload, server.logger)
+  const contacts = await findContactsForAlert(payload, logger)
   if (!contacts?.length) {
-    server.logger.info(
-      `No contact details found ${payload.service}. Not sending alert - MessageId: ${message.MessageId}`
+    logger.info(
+      `No contact details found ${payload.service}. Not sending alert`
     )
     return
   }
 
-  server.logger.debug(`Sending alert to ${contacts.join(',')}`)
-  server.logger.info(
-    `Grafana alert ${payload.status} for ${payload.service} in ${payload.environment} - Alert: ${payload.alertName} MessageId: ${message.MessageId}`
+  logger.debug(`Sending alert to ${contacts.join(',')}`)
+  logger.info(
+    `Grafana alert ${payload.status} for ${payload.service} in ${payload.environment} - Alert: ${payload.alertName}`
   )
 
   if (sendEmailAlerts) {
-    server.logger.info('Sending email alert')
-    await sendEmail(server.msGraph, sender, email, contacts)
+    logger.info('Sending email alert')
+    await sendEmail(msGraph, sender, email, contacts)
   }
 }
 

--- a/src/listeners/grafana/email/handle-grafana-email-alerts.test.js
+++ b/src/listeners/grafana/email/handle-grafana-email-alerts.test.js
@@ -30,7 +30,7 @@ describe('#handle-grafana-alerts', () => {
         service: 'test-service'
       })
     }
-    await handleGrafanaEmailAlert(message, server)
+    await handleGrafanaEmailAlert(message, server.logger, server.msGraph)
 
     expect(sendEmail).not.toHaveBeenCalled()
   })
@@ -47,7 +47,7 @@ describe('#handle-grafana-alerts', () => {
     const message = {
       Body: JSON.stringify(alert)
     }
-    await handleGrafanaEmailAlert(message, server)
+    await handleGrafanaEmailAlert(message, server.logger, server.msGraph)
 
     const sender = config.get('senderEmailAddress')
     expect(sendEmail).toHaveBeenCalledTimes(1)
@@ -77,7 +77,7 @@ describe('#handle-grafana-alerts', () => {
     const message = {
       Body: JSON.stringify(alert)
     }
-    await handleGrafanaEmailAlert(message, server)
+    await handleGrafanaEmailAlert(message, server.logger, server.msGraph)
 
     const sender = config.get('senderEmailAddress')
     expect(sendEmail).toHaveBeenCalledTimes(1)
@@ -117,7 +117,7 @@ describe('#handle-grafana-alerts', () => {
     const message = {
       Body: JSON.stringify(alert)
     }
-    await handleGrafanaEmailAlert(message, server)
+    await handleGrafanaEmailAlert(message, server.logger, server.msGraph)
 
     const sender = config.get('senderEmailAddress')
     expect(sendEmail).toHaveBeenCalledTimes(1)
@@ -157,7 +157,7 @@ describe('#handle-grafana-alerts', () => {
     const message = {
       Body: JSON.stringify(alert)
     }
-    await handleGrafanaEmailAlert(message, server)
+    await handleGrafanaEmailAlert(message, server.logger, server.msGraph)
 
     const sender = config.get('senderEmailAddress')
     expect(sendEmail).toHaveBeenCalledTimes(1)
@@ -184,7 +184,7 @@ describe('#handle-grafana-alerts', () => {
     const message = {
       Body: JSON.stringify(alert)
     }
-    await handleGrafanaEmailAlert(message, server)
+    await handleGrafanaEmailAlert(message, server.logger, server.msGraph)
 
     expect(sendEmail).toHaveBeenCalledTimes(1)
 
@@ -207,7 +207,7 @@ describe('#handle-grafana-alerts', () => {
     const message = {
       Body: JSON.stringify({ ...alert, status: 'resolved' })
     }
-    await handleGrafanaEmailAlert(message, server)
+    await handleGrafanaEmailAlert(message, server.logger, server.msGraph)
 
     expect(sendEmail).toHaveBeenCalledTimes(1)
 


### PR DESCRIPTION
Changes:
- Add support for `Trade-Data-Matching`
- Log out the PagerDuty body in error responses (400 Bad Request isn't helpful atm)
- Add a logging context using `event`, which contains the message.Body from SQS and log PagerDuty payload under tenant/message (this doesn't contain any sensitive data)