### PR TITLE
Switches to the entities endpoint for service info

### DIFF
--- a/src/helpers/fetch/fetch-service.js
+++ b/src/helpers/fetch/fetch-service.js
@@ -3,10 +3,10 @@ import { config } from '~/src/config/index.js'
 /**
  * Fetch Service info from portal backend.
  * @param {string} name
- * @returns {Promise<{teams: [{name: string}] }|null>}
+ * @returns {Promise<{teams: [{name: string, teamId: string}] }|null>}
  */
 async function fetchService(name) {
-  const endpoint = config.get('portalBackendUrl') + `/services/${name}`
+  const endpoint = config.get('portalBackendUrl') + `/entities/${name}`
   const response = await fetch(endpoint, {
     method: 'get',
     headers: { 'Content-Type': 'application/json' }


### PR DESCRIPTION
The old `/service/id` endpoint was based off the artifact collection which is likely to be deprecated soon.
Also, the team data on this endpoint was not being resynced with github so could potentially be incorrect if a service changes ownership.